### PR TITLE
Sort pages by priority

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,20 +1,25 @@
 module.exports = function (config) {
     // Layouts
-    config.addLayoutAlias('base', 'base.njk');
+    config.addLayoutAlias('base', 'base.njk')
 
     // Copy CSS
-    config.addPassthroughCopy("src/static");
+    config.addPassthroughCopy("src/static")
 
     // Add stats filters
     config.addFilter("count", function(collection) {
-        return collection.length;
-    });
+        return collection.length
+    })
     config.addFilter("combinations", function(collection) {
-        return collection.length * (collection.length - 1);
-    });
+        return collection.length * (collection.length - 1)
+    })
     config.addFilter("quote", function(collection) {
         return collection.map(w => `"${w}"`)
-    });
+    })
+
+    // Add sorting
+    config.addFilter("sortedByPriority", function(collection) {
+        return collection.sort((a, b) => a["data"]["priority"] - b["data"]["priority"])
+    })
 
     return {
         dir: {
@@ -29,4 +34,4 @@ module.exports = function (config) {
         markdownTemplateEngine: 'njk',
         passthroughFileCopy: true
     }
-};
+}

--- a/src/includes/nav.njk
+++ b/src/includes/nav.njk
@@ -1,6 +1,6 @@
 <nav>
   <ul role="nav">
-    {% for page in collections.all %}
+    {% for page in collections.navpage | sortedByPriority %}
       <li>
         <a href="{{page.url}}">{{page.data.title}}</a>
       </li>

--- a/src/pages/all.njk
+++ b/src/pages/all.njk
@@ -1,6 +1,7 @@
 ---
-layout: base
 title: Alle ord
+permalink: /alle/
+priority: 20
 ---
 
 <div id="allWords">

--- a/src/pages/index.njk
+++ b/src/pages/index.njk
@@ -1,6 +1,7 @@
 ---
-layout: base
 title: Tilfeldig ord
+permalink: /
+priority: 10
 ---
 
 <script src="/static/app.js"></script>

--- a/src/pages/pages.json
+++ b/src/pages/pages.json
@@ -1,0 +1,4 @@
+{
+    "layout": "base",
+    "tags": "navpage"
+}

--- a/src/pages/stats.njk
+++ b/src/pages/stats.njk
@@ -1,6 +1,7 @@
 ---
-layout: base
 title: Statistikk
+permalink: /statistikk/
+priority: 30
 ---
 
 <div id="statistics">


### PR DESCRIPTION
Allows pages to be sorted by front matter YAML data `priority`. Also, moved all pages to `src/pages` and added `navpage` tags to all pages.

Also, linting.

Referenced issues:
* Fixes #7